### PR TITLE
Run initializer tests twice

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,15 @@ jobs:
       - id: git-checkout
         name: Checkout
         uses: actions/checkout@v3
-      - id: test-script
-        name: Test the initializers
+      - id: test-script-1
+        name: Test the initializers (First run)
+        env:
+          KEEP_VOLUMES: "true"
+        run: |
+          cd test
+          ./test.sh
+      - id: test-script-2
+        name: Test the initializers (Second run)
         run: |
           cd test
           ./test.sh

--- a/src/netbox_initializers/initializers/interfaces.py
+++ b/src/netbox_initializers/initializers/interfaces.py
@@ -65,7 +65,6 @@ class InterfaceInitializer(BaseInitializer):
                     query = {
                         r_field: related_value,
                         "device": interface.device,
-                        "type": related_field,
                     }
                     related_obj, rel_obj_created = r_model.objects.get_or_create(**query)
 

--- a/src/netbox_initializers/initializers/object_permissions.py
+++ b/src/netbox_initializers/initializers/object_permissions.py
@@ -44,8 +44,8 @@ class ObjectPermissionInitializer(BaseInitializer):
                                 object_permission.object_types.add(
                                     ContentType.objects.get(app_label=app_label, model=model)
                                 )
-
-            print("🔓 Created object permission", object_permission.name)
+            if created:
+                print("🔓 Created object permission", object_permission.name)
 
             if permission_details.get("groups", 0):
                 for groupname in permission_details["groups"]:

--- a/test/test.sh
+++ b/test/test.sh
@@ -22,6 +22,7 @@ test_setup() {
     done
   )
   $doco build --no-cache || exit 1
+  $doco run --rm netbox /opt/netbox/docker-entrypoint.sh ./manage.py check || exit 1
 }
 
 test_cleanup() {

--- a/test/test.sh
+++ b/test/test.sh
@@ -27,7 +27,11 @@ test_setup() {
 test_cleanup() {
   gh_echo "::group::Clean test environment"
   echo "💣 Cleaning Up"
-  $doco down -v
+  if [ "$KEEP_VOLUMES" == "true" ]; then
+    $doco down
+  else
+    $doco down -v
+  fi
 
   if [ -d "${INITIALIZERS_DIR}" ]; then
     rm -rf "${INITIALIZERS_DIR}"


### PR DESCRIPTION
The second test will catch errors when the initializers a run a second time against an already initialized database.