### PR TITLE
Allow creation of duplicated IP addresses

### DIFF
--- a/src/netbox_initializers/initializers/ip_addresses.py
+++ b/src/netbox_initializers/initializers/ip_addresses.py
@@ -8,7 +8,7 @@ from virtualization.models import VirtualMachine, VMInterface
 
 from . import BaseInitializer, InitializationError, register_initializer
 
-MATCH_PARAMS = ["address", "vrf", "vrf_id"]
+MATCH_PARAMS = ["address", "vrf", "vrf_id", "assigned_object_id", "assigned_object_type"]
 OPTIONAL_ASSOCS = {
     "tenant": (Tenant, "name"),
     "vrf": (VRF, "name"),

--- a/src/netbox_initializers/initializers/yaml/ip_addresses.yml
+++ b/src/netbox_initializers/initializers/yaml/ip_addresses.yml
@@ -21,6 +21,11 @@
 #   interface: to-server02
 #   status: active
 #   vrf: vrf1
+# - address: 10.1.1.1/24
+#   device: server02
+#   interface: to-server01
+#   status: active
+#   vrf: vrf1
 # - address: 2001:db8:a000:1::1/64
 #   device: server01
 #   interface: to-server02


### PR DESCRIPTION
In netbox, it is allowed to create duplicated ip addresses. This can be useful if multiple devices share the same IP address.

This patch matches ip addresses on input assigned objects types and ids.