### PR TITLE
Tag Content Type Restrictions

### DIFF
--- a/src/netbox_initializers/initializers/tags.py
+++ b/src/netbox_initializers/initializers/tags.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from extras.models import Tag
 from utilities.choices import ColorChoices
 
@@ -19,11 +20,21 @@ class TagInitializer(BaseInitializer):
                     if color in color_tpl:
                         params["color"] = color_tpl[0]
 
+            object_types = params.pop("object_types", None)
             matching_params, defaults = self.split_params(params)
             tag, created = Tag.objects.get_or_create(**matching_params, defaults=defaults)
 
             if created:
                 print("🎨 Created Tag", tag.name)
+
+                if object_types:
+                    for ot in object_types:
+                        ct = ContentType.objects.get(
+                            app_label=ot["app"],
+                            model=ot["model"],
+                        )
+                        tag.object_types.add(ct)
+                        print(f"🎨 Restricted Tag {tag.name} to {ot['app']}.{ot['model']}")
 
 
 register_initializer("tags", TagInitializer)

--- a/src/netbox_initializers/initializers/yaml/tags.yml
+++ b/src/netbox_initializers/initializers/yaml/tags.yml
@@ -10,3 +10,9 @@
 # - name: Tag 4
 #   slug: tag-4
 #   color: Teal
+# - name: Tag 5
+#   slug: tag-5
+#   color: Teal
+#   object_types:
+#     - app: ipam
+#       model: ipaddress


### PR DESCRIPTION
Add support for restricting tags to specific content types. e.g.:

```
- name: Tag 5
  slug: tag-5
  color: Teal
  object_types:
    - app: ipam
      model: ipaddress
```