### PR TITLE
Support Tagging Objects

### DIFF
--- a/src/netbox_initializers/initializers/aggregates.py
+++ b/src/netbox_initializers/initializers/aggregates.py
@@ -20,6 +20,7 @@ class AggregateInitializer(BaseInitializer):
             return
         for params in aggregates:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             params["prefix"] = IPNetwork(params["prefix"])
 
@@ -45,6 +46,7 @@ class AggregateInitializer(BaseInitializer):
                 print("🗞️ Created Aggregate", aggregate.prefix)
 
             self.set_custom_fields_values(aggregate, custom_field_data)
+            self.set_tags(aggregate, tags)
 
 
 register_initializer("aggregates", AggregateInitializer)

--- a/src/netbox_initializers/initializers/asns.py
+++ b/src/netbox_initializers/initializers/asns.py
@@ -16,6 +16,7 @@ class ASNInitializer(BaseInitializer):
         if asns is None:
             return
         for params in asns:
+            tags = params.pop("tags", None)
             for assoc, details in REQUIRED_ASSOCS.items():
                 model, field = details
                 query = {field: params.pop(assoc)}
@@ -34,6 +35,8 @@ class ASNInitializer(BaseInitializer):
 
             if created:
                 print(f"🔡 Created ASN {asn.asn}")
+
+            self.set_tags(asn, tags)
 
 
 register_initializer("asns", ASNInitializer)

--- a/src/netbox_initializers/initializers/cables.py
+++ b/src/netbox_initializers/initializers/cables.py
@@ -202,6 +202,8 @@ class CableInitializer(BaseInitializer):
         if cables is None:
             return
         for params in cables:
+            tags = params.pop("tags", None)
+
             params["termination_a_class"] = get_termination_class_by_name(
                 params.get("termination_a_class")
             )
@@ -248,6 +250,7 @@ class CableInitializer(BaseInitializer):
             CableTermination.objects.create(**params_b_term)
 
             print(f"🧷 Created cable {cable} {cable_name}")
+            self.set_tags(cable, tags)
 
 
 register_initializer("cables", CableInitializer)

--- a/src/netbox_initializers/initializers/circuit_types.py
+++ b/src/netbox_initializers/initializers/circuit_types.py
@@ -11,6 +11,7 @@ class CircuitTypeInitializer(BaseInitializer):
         if circuit_types is None:
             return
         for params in circuit_types:
+            tags = params.pop("tags", None)
             custom_field_data = self.pop_custom_fields(params)
 
             matching_params, defaults = self.split_params(params)
@@ -22,6 +23,7 @@ class CircuitTypeInitializer(BaseInitializer):
                 print("⚡ Created Circuit Type", circuit_type.name)
 
             self.set_custom_fields_values(circuit_type, custom_field_data)
+            self.set_tags(circuit_type, tags)
 
 
 register_initializer("circuit_types", CircuitTypeInitializer)

--- a/src/netbox_initializers/initializers/circuits.py
+++ b/src/netbox_initializers/initializers/circuits.py
@@ -17,6 +17,7 @@ class CircuitInitializer(BaseInitializer):
             return
         for params in circuits:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in REQUIRED_ASSOCS.items():
                 model, field = details
@@ -38,6 +39,7 @@ class CircuitInitializer(BaseInitializer):
                 print("⚡ Created Circuit", circuit.cid)
 
             self.set_custom_fields_values(circuit, custom_field_data)
+            self.set_tags(circuit, tags)
 
 
 register_initializer("circuits", CircuitInitializer)

--- a/src/netbox_initializers/initializers/cluster_groups.py
+++ b/src/netbox_initializers/initializers/cluster_groups.py
@@ -11,6 +11,7 @@ class ClusterGroupInitializer(BaseInitializer):
         if cluster_groups is None:
             return
         for params in cluster_groups:
+            tags = params.pop("tags", None)
             matching_params, defaults = self.split_params(params)
             cluster_group, created = ClusterGroup.objects.get_or_create(
                 **matching_params, defaults=defaults
@@ -18,6 +19,7 @@ class ClusterGroupInitializer(BaseInitializer):
 
             if created:
                 print("🗄️ Created Cluster Group", cluster_group.name)
+            self.set_tags(cluster_group, tags)
 
 
 register_initializer("cluster_groups", ClusterGroupInitializer)

--- a/src/netbox_initializers/initializers/cluster_types.py
+++ b/src/netbox_initializers/initializers/cluster_types.py
@@ -11,6 +11,7 @@ class ClusterTypesInitializer(BaseInitializer):
         if cluster_types is None:
             return
         for params in cluster_types:
+            tags = params.pop("tags", None)
             matching_params, defaults = self.split_params(params)
             cluster_type, created = ClusterType.objects.get_or_create(
                 **matching_params, defaults=defaults
@@ -18,6 +19,7 @@ class ClusterTypesInitializer(BaseInitializer):
 
             if created:
                 print("🧰 Created Cluster Type", cluster_type.name)
+            self.set_tags(cluster_type, tags)
 
 
 register_initializer("cluster_types", ClusterTypesInitializer)

--- a/src/netbox_initializers/initializers/clusters.py
+++ b/src/netbox_initializers/initializers/clusters.py
@@ -22,6 +22,7 @@ class ClusterInitializer(BaseInitializer):
             return
         for params in clusters:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in REQUIRED_ASSOCS.items():
                 model, field = details
@@ -43,6 +44,7 @@ class ClusterInitializer(BaseInitializer):
                 print("🗄️ Created cluster", cluster.name)
 
             self.set_custom_fields_values(cluster, custom_field_data)
+            self.set_tags(cluster, tags)
 
 
 register_initializer("clusters", ClusterInitializer)

--- a/src/netbox_initializers/initializers/config_templates.py
+++ b/src/netbox_initializers/initializers/config_templates.py
@@ -22,6 +22,7 @@ class ConfigTemplateInitializer(BaseInitializer):
         if config_templates is None:
             return
         for template in config_templates:
+            tags = template.pop("tags", None)
             matching_params, defaults = self.split_params(template)
             config_template, created = ConfigTemplate.objects.get_or_create(
                 **matching_params, defaults=defaults
@@ -30,6 +31,7 @@ class ConfigTemplateInitializer(BaseInitializer):
             if created:
                 config_template.save()
                 print("🪝 Created Config Template {0}".format(config_template.name))
+            self.set_tags(config_template, tags)
 
 
 register_initializer("config_templates", ConfigTemplateInitializer)

--- a/src/netbox_initializers/initializers/contact_groups.py
+++ b/src/netbox_initializers/initializers/contact_groups.py
@@ -14,6 +14,7 @@ class ContactGroupInitializer(BaseInitializer):
             return
         for params in contact_groups:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -31,6 +32,7 @@ class ContactGroupInitializer(BaseInitializer):
                 print("🔳 Created Contact Group", contact_group.name)
 
             self.set_custom_fields_values(contact_group, custom_field_data)
+            self.set_tags(contact_group, tags)
 
 
 register_initializer("contact_groups", ContactGroupInitializer)

--- a/src/netbox_initializers/initializers/contact_roles.py
+++ b/src/netbox_initializers/initializers/contact_roles.py
@@ -12,6 +12,7 @@ class ContactRoleInitializer(BaseInitializer):
             return
         for params in contact_roles:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             matching_params, defaults = self.split_params(params)
             contact_role, created = ContactRole.objects.get_or_create(
@@ -22,6 +23,7 @@ class ContactRoleInitializer(BaseInitializer):
                 print("🔳 Created Contact Role", contact_role.name)
 
             self.set_custom_fields_values(contact_role, custom_field_data)
+            self.set_tags(contact_role, tags)
 
 
 register_initializer("contact_roles", ContactRoleInitializer)

--- a/src/netbox_initializers/initializers/contacts.py
+++ b/src/netbox_initializers/initializers/contacts.py
@@ -14,6 +14,7 @@ class ContactInitializer(BaseInitializer):
             return
         for params in contacts:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -29,6 +30,7 @@ class ContactInitializer(BaseInitializer):
                 print("👩‍💻 Created Contact", contact.name)
 
             self.set_custom_fields_values(contact, custom_field_data)
+            self.set_tags(contact, tags)
 
 
 register_initializer("contacts", ContactInitializer)

--- a/src/netbox_initializers/initializers/device_roles.py
+++ b/src/netbox_initializers/initializers/device_roles.py
@@ -12,6 +12,7 @@ class DeviceRoleInitializer(BaseInitializer):
         if device_roles is None:
             return
         for params in device_roles:
+            tags = params.pop("tags", None)
 
             if "color" in params:
                 color = params.pop("color")
@@ -27,6 +28,8 @@ class DeviceRoleInitializer(BaseInitializer):
 
             if created:
                 print("🎨 Created device role", device_role.name)
+
+            self.set_tags(device_role, tags)
 
 
 register_initializer("device_roles", DeviceRoleInitializer)

--- a/src/netbox_initializers/initializers/device_types.py
+++ b/src/netbox_initializers/initializers/device_types.py
@@ -85,6 +85,7 @@ class DeviceTypeInitializer(BaseInitializer):
             return
         for params in device_types:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
             components = [(v[0], v[1], params.pop(k, [])) for k, v in SUPPORTED_COMPONENTS.items()]
 
             for assoc, details in REQUIRED_ASSOCS.items():
@@ -109,6 +110,7 @@ class DeviceTypeInitializer(BaseInitializer):
                 print("🔡 Created device type", device_type.manufacturer, device_type.model)
 
             self.set_custom_fields_values(device_type, custom_field_data)
+            self.set_tags(device_type, tags)
 
             for component in components:
                 c_model, c_match_params, c_params = component

--- a/src/netbox_initializers/initializers/devices.py
+++ b/src/netbox_initializers/initializers/devices.py
@@ -30,6 +30,7 @@ class DeviceInitializer(BaseInitializer):
             return
         for params in devices:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             # primary ips are handled later in `380_primary_ips.py`
             params.pop("primary_ip4", None)
@@ -57,6 +58,7 @@ class DeviceInitializer(BaseInitializer):
                 print("🖥️  Created device", device.name)
 
             self.set_custom_fields_values(device, custom_field_data)
+            self.set_tags(device, tags)
 
 
 register_initializer("devices", DeviceInitializer)

--- a/src/netbox_initializers/initializers/interfaces.py
+++ b/src/netbox_initializers/initializers/interfaces.py
@@ -24,6 +24,7 @@ class InterfaceInitializer(BaseInitializer):
             return
         for params in interfaces:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             related_interfaces = {k: params.pop(k, None) for k in RELATED_ASSOCS}
 
@@ -49,6 +50,7 @@ class InterfaceInitializer(BaseInitializer):
                 print(f"🧷 Created interface {interface} on {interface.device}")
 
             self.set_custom_fields_values(interface, custom_field_data)
+            self.set_tags(interface, tags)
 
             for related_field, related_value in related_interfaces.items():
                 if not related_value:

--- a/src/netbox_initializers/initializers/ip_addresses.py
+++ b/src/netbox_initializers/initializers/ip_addresses.py
@@ -30,6 +30,7 @@ class IPAddressInitializer(BaseInitializer):
             return
         for params in ip_addresses:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             vm = params.pop("virtual_machine", None)
             device = params.pop("device", None)
@@ -70,6 +71,7 @@ class IPAddressInitializer(BaseInitializer):
                 print("🧬 Created IP Address", ip_address.address)
 
             self.set_custom_fields_values(ip_address, custom_field_data)
+            self.set_tags(ip_address, tags)
 
 
 register_initializer("ip_addresses", IPAddressInitializer)

--- a/src/netbox_initializers/initializers/locations.py
+++ b/src/netbox_initializers/initializers/locations.py
@@ -13,6 +13,7 @@ class LocationInitializer(BaseInitializer):
         if locations is None:
             return
         for params in locations:
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -25,6 +26,8 @@ class LocationInitializer(BaseInitializer):
 
             if created:
                 print("🎨 Created location", location.name)
+
+            self.set_tags(location, tags)
 
 
 register_initializer("locations", LocationInitializer)

--- a/src/netbox_initializers/initializers/manufacturers.py
+++ b/src/netbox_initializers/initializers/manufacturers.py
@@ -11,6 +11,7 @@ class ManufacturerInitializer(BaseInitializer):
         if manufacturers is None:
             return
         for params in manufacturers:
+            tags = params.pop("tags", None)
             matching_params, defaults = self.split_params(params)
             manufacturer, created = Manufacturer.objects.get_or_create(
                 **matching_params, defaults=defaults
@@ -18,6 +19,8 @@ class ManufacturerInitializer(BaseInitializer):
 
             if created:
                 print("🏭 Created Manufacturer", manufacturer.name)
+
+            self.set_tags(manufacturer, tags)
 
 
 register_initializer("manufacturers", ManufacturerInitializer)

--- a/src/netbox_initializers/initializers/platforms.py
+++ b/src/netbox_initializers/initializers/platforms.py
@@ -15,6 +15,7 @@ class PlatformInitializer(BaseInitializer):
         if platforms is None:
             return
         for params in platforms:
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -28,6 +29,8 @@ class PlatformInitializer(BaseInitializer):
 
             if created:
                 print("💾 Created platform", platform.name)
+
+            self.set_tags(platform, tags)
 
 
 register_initializer("platforms", PlatformInitializer)

--- a/src/netbox_initializers/initializers/power_feeds.py
+++ b/src/netbox_initializers/initializers/power_feeds.py
@@ -16,6 +16,7 @@ class PowerFeedInitializer(BaseInitializer):
             return
         for params in power_feeds:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in REQUIRED_ASSOCS.items():
                 model, field = details
@@ -39,6 +40,7 @@ class PowerFeedInitializer(BaseInitializer):
                 print("⚡ Created Power Feed", power_feed.name)
 
             self.set_custom_fields_values(power_feed, custom_field_data)
+            self.set_tags(power_feed, tags)
 
 
 register_initializer("power_feeds", PowerFeedInitializer)

--- a/src/netbox_initializers/initializers/power_panels.py
+++ b/src/netbox_initializers/initializers/power_panels.py
@@ -16,6 +16,7 @@ class PowerPanelInitializer(BaseInitializer):
             return
         for params in power_panels:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in REQUIRED_ASSOCS.items():
                 model, field = details
@@ -39,6 +40,7 @@ class PowerPanelInitializer(BaseInitializer):
                 print("⚡ Created Power Panel", power_panel.site, power_panel.name)
 
             self.set_custom_fields_values(power_panel, custom_field_data)
+            self.set_tags(power_panel, tags)
 
 
 register_initializer("power_panels", PowerPanelInitializer)

--- a/src/netbox_initializers/initializers/prefix_vlan_roles.py
+++ b/src/netbox_initializers/initializers/prefix_vlan_roles.py
@@ -11,11 +11,14 @@ class RoleInitializer(BaseInitializer):
         if roles is None:
             return
         for params in roles:
+            tags = params.pop("tags", None)
             matching_params, defaults = self.split_params(params)
             role, created = Role.objects.get_or_create(**matching_params, defaults=defaults)
 
             if created:
                 print("⛹️‍ Created Prefix/VLAN Role", role.name)
+
+            self.set_tags(role, tags)
 
 
 register_initializer("prefix_vlan_roles", RoleInitializer)

--- a/src/netbox_initializers/initializers/prefixes.py
+++ b/src/netbox_initializers/initializers/prefixes.py
@@ -25,6 +25,7 @@ class PrefixInitializer(BaseInitializer):
             return
         for params in prefixes:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             params["prefix"] = IPNetwork(params["prefix"])
 
@@ -41,6 +42,7 @@ class PrefixInitializer(BaseInitializer):
                 print("📌 Created Prefix", prefix.prefix)
 
             self.set_custom_fields_values(prefix, custom_field_data)
+            self.set_tags(prefix, tags)
 
 
 register_initializer("prefixes", PrefixInitializer)

--- a/src/netbox_initializers/initializers/providers.py
+++ b/src/netbox_initializers/initializers/providers.py
@@ -13,6 +13,7 @@ class ProviderInitializer(BaseInitializer):
             return
         for params in providers:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             asn_number = params.pop("asn")
             asn = ASN.objects.filter(asn=asn_number).first()
@@ -33,6 +34,7 @@ class ProviderInitializer(BaseInitializer):
                 print("📡 Created provider", provider.name)
 
             self.set_custom_fields_values(provider, custom_field_data)
+            self.set_tags(provider, tags)
 
 
 register_initializer("providers", ProviderInitializer)

--- a/src/netbox_initializers/initializers/rack_roles.py
+++ b/src/netbox_initializers/initializers/rack_roles.py
@@ -12,6 +12,7 @@ class RackRoleInitializer(BaseInitializer):
         if rack_roles is None:
             return
         for params in rack_roles:
+            tags = params.pop("tags", None)
             if "color" in params:
                 color = params.pop("color")
 
@@ -26,6 +27,8 @@ class RackRoleInitializer(BaseInitializer):
 
             if created:
                 print("🎨 Created rack role", rack_role.name)
+
+            self.set_tags(rack_role, tags)
 
 
 register_initializer("rack_roles", RackRoleInitializer)

--- a/src/netbox_initializers/initializers/racks.py
+++ b/src/netbox_initializers/initializers/racks.py
@@ -21,6 +21,7 @@ class RackInitializer(BaseInitializer):
             return
         for params in racks:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in REQUIRED_ASSOCS.items():
                 model, field = details
@@ -42,6 +43,7 @@ class RackInitializer(BaseInitializer):
                 print("🔳 Created rack", rack.site, rack.name)
 
             self.set_custom_fields_values(rack, custom_field_data)
+            self.set_tags(rack, tags)
 
 
 register_initializer("racks", RackInitializer)

--- a/src/netbox_initializers/initializers/regions.py
+++ b/src/netbox_initializers/initializers/regions.py
@@ -13,6 +13,7 @@ class RegionInitializer(BaseInitializer):
         if regions is None:
             return
         for params in regions:
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -26,6 +27,8 @@ class RegionInitializer(BaseInitializer):
 
             if created:
                 print("🌐 Created region", region.name)
+
+            self.set_tags(region, tags)
 
 
 register_initializer("regions", RegionInitializer)

--- a/src/netbox_initializers/initializers/rirs.py
+++ b/src/netbox_initializers/initializers/rirs.py
@@ -12,11 +12,14 @@ class RIRInitializer(BaseInitializer):
             return
 
         for params in rirs:
+            tags = params.pop("tags", None)
             matching_params, defaults = self.split_params(params)
             rir, created = RIR.objects.get_or_create(**matching_params, defaults=defaults)
 
             if created:
                 print("🗺️ Created RIR", rir.name)
+
+            self.set_tags(rir, tags)
 
 
 register_initializer("rirs", RIRInitializer)

--- a/src/netbox_initializers/initializers/route_targets.py
+++ b/src/netbox_initializers/initializers/route_targets.py
@@ -15,6 +15,7 @@ class RouteTargetInitializer(BaseInitializer):
             return
         for params in route_targets:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -32,6 +33,7 @@ class RouteTargetInitializer(BaseInitializer):
                 print("🎯 Created Route Target", route_target.name)
 
             self.set_custom_fields_values(route_target, custom_field_data)
+            self.set_tags(route_target, tags)
 
 
 register_initializer("route_targets", RouteTargetInitializer)

--- a/src/netbox_initializers/initializers/service_templates.py
+++ b/src/netbox_initializers/initializers/service_templates.py
@@ -13,6 +13,7 @@ class ServiceTemplateInitializer(BaseInitializer):
         if service_templates is None:
             return
         for params in service_templates:
+            tags = params.pop("tags", None)
             matching_params, defaults = self.split_params(params, MATCH_PARAMS)
             service_template, created = ServiceTemplate.objects.get_or_create(
                 **matching_params, defaults=defaults
@@ -20,6 +21,8 @@ class ServiceTemplateInitializer(BaseInitializer):
 
             if created:
                 print("🧰 Created Service Template", service_template.name)
+
+            self.set_tags(service_template, tags)
 
 
 register_initializer("service_templates", ServiceTemplateInitializer)

--- a/src/netbox_initializers/initializers/services.py
+++ b/src/netbox_initializers/initializers/services.py
@@ -19,6 +19,7 @@ class ServiceInitializer(BaseInitializer):
         if services is None:
             return
         for params in services:
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -31,6 +32,8 @@ class ServiceInitializer(BaseInitializer):
 
             if created:
                 print("🧰 Created Service", service.name)
+
+            self.set_tags(service, tags)
 
 
 register_initializer("services", ServiceInitializer)

--- a/src/netbox_initializers/initializers/sites.py
+++ b/src/netbox_initializers/initializers/sites.py
@@ -16,6 +16,7 @@ class SiteInitializer(BaseInitializer):
             return
         for params in sites:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -49,6 +50,7 @@ class SiteInitializer(BaseInitializer):
                 print("📍 Created site", site.name)
 
             self.set_custom_fields_values(site, custom_field_data)
+            self.set_tags(site, tags)
 
             for asn in asnFounds:
                 site.asns.add(asn)

--- a/src/netbox_initializers/initializers/tenant_groups.py
+++ b/src/netbox_initializers/initializers/tenant_groups.py
@@ -11,6 +11,7 @@ class TenantGroupInitializer(BaseInitializer):
         if tenant_groups is None:
             return
         for params in tenant_groups:
+            tags = params.pop("tags", None)
             matching_params, defaults = self.split_params(params)
             tenant_group, created = TenantGroup.objects.get_or_create(
                 **matching_params, defaults=defaults
@@ -18,6 +19,8 @@ class TenantGroupInitializer(BaseInitializer):
 
             if created:
                 print("🔳 Created Tenant Group", tenant_group.name)
+
+            self.set_tags(tenant_group, tags)
 
 
 register_initializer("tenant_groups", TenantGroupInitializer)

--- a/src/netbox_initializers/initializers/tenants.py
+++ b/src/netbox_initializers/initializers/tenants.py
@@ -14,6 +14,7 @@ class TenantInitializer(BaseInitializer):
             return
         for params in tenants:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -29,6 +30,7 @@ class TenantInitializer(BaseInitializer):
                 print("👩‍💻 Created Tenant", tenant.name)
 
             self.set_custom_fields_values(tenant, custom_field_data)
+            self.set_tags(tenant, tags)
 
 
 register_initializer("tenants", TenantInitializer)

--- a/src/netbox_initializers/initializers/virtual_machines.py
+++ b/src/netbox_initializers/initializers/virtual_machines.py
@@ -23,6 +23,7 @@ class VirtualMachineInitializer(BaseInitializer):
             return
         for params in virtual_machines:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             # primary ips are handled later in `270_primary_ips.py`
             params.pop("primary_ip4", None)
@@ -52,6 +53,7 @@ class VirtualMachineInitializer(BaseInitializer):
                 print("🖥️ Created virtual machine", virtual_machine.name)
 
             self.set_custom_fields_values(virtual_machine, custom_field_data)
+            self.set_tags(virtual_machine, tags)
 
 
 register_initializer("virtual_machines", VirtualMachineInitializer)

--- a/src/netbox_initializers/initializers/virtualization_interfaces.py
+++ b/src/netbox_initializers/initializers/virtualization_interfaces.py
@@ -15,6 +15,7 @@ class VMInterfaceInitializer(BaseInitializer):
             return
         for params in interfaces:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in REQUIRED_ASSOCS.items():
                 model, field = details
@@ -31,6 +32,7 @@ class VMInterfaceInitializer(BaseInitializer):
                 print("🧷 Created interface", interface.name, interface.virtual_machine.name)
 
             self.set_custom_fields_values(interface, custom_field_data)
+            self.set_tags(interface, tags)
 
 
 register_initializer("virtualization_interfaces", VMInterfaceInitializer)

--- a/src/netbox_initializers/initializers/vlan_groups.py
+++ b/src/netbox_initializers/initializers/vlan_groups.py
@@ -15,6 +15,7 @@ class VLANGroupInitializer(BaseInitializer):
             return
         for params in vlan_groups:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -47,6 +48,7 @@ class VLANGroupInitializer(BaseInitializer):
                 print("🏘️ Created VLAN Group", vlan_group.name)
 
             self.set_custom_fields_values(vlan_group, custom_field_data)
+            self.set_tags(vlan_group, tags)
 
 
 register_initializer("vlan_groups", VLANGroupInitializer)

--- a/src/netbox_initializers/initializers/vlans.py
+++ b/src/netbox_initializers/initializers/vlans.py
@@ -23,6 +23,7 @@ class VLANInitializer(BaseInitializer):
             return
         for params in vlans:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -38,6 +39,7 @@ class VLANInitializer(BaseInitializer):
                 print("🏠 Created VLAN", vlan.name)
 
             self.set_custom_fields_values(vlan, custom_field_data)
+            self.set_tags(vlan, tags)
 
 
 register_initializer("vlans", VLANInitializer)

--- a/src/netbox_initializers/initializers/vrfs.py
+++ b/src/netbox_initializers/initializers/vrfs.py
@@ -16,6 +16,7 @@ class VRFInitializer(BaseInitializer):
             return
         for params in vrfs:
             custom_field_data = self.pop_custom_fields(params)
+            tags = params.pop("tags", None)
 
             for assoc, details in OPTIONAL_ASSOCS.items():
                 if assoc in params:
@@ -31,6 +32,7 @@ class VRFInitializer(BaseInitializer):
                 print("📦 Created VRF", vrf.name)
 
             self.set_custom_fields_values(vrf, custom_field_data)
+            self.set_tags(vrf, tags)
 
 
 register_initializer("vrfs", VRFInitializer)

--- a/src/netbox_initializers/initializers/webhooks.py
+++ b/src/netbox_initializers/initializers/webhooks.py
@@ -20,11 +20,14 @@ class WebhookInitializer(BaseInitializer):
         if webhooks is None:
             return
         for hook in webhooks:
+            tags = hook.pop("tags", None)
             matching_params, defaults = self.split_params(hook)
             webhook, created = Webhook.objects.get_or_create(**matching_params, defaults=defaults)
 
             if created:
                 print("🪝 Created Webhook {0}".format(webhook.name))
+
+            self.set_tags(webhook, tags)
 
 
 register_initializer("webhooks", WebhookInitializer)


### PR DESCRIPTION
Support for tagging is added to all types that are initialized after tags.

If a type does not include tags support in netbox, an exception will be raised alerting the user to the fact.

Tags must be pre-existing.

Example:

```yaml
- address: 10.1.1.1
  status: active
  tags:
    - MyTag
```