### PR TITLE
Support New Interface on Pre-Existing Related Interface

### DIFF
--- a/src/netbox_initializers/initializers/interfaces.py
+++ b/src/netbox_initializers/initializers/interfaces.py
@@ -82,11 +82,12 @@ class InterfaceInitializer(BaseInitializer):
                     related_obj, rel_obj_created = r_model.objects.get_or_create(**query)
 
                     if rel_obj_created:
-                        setattr(interface, f"{related_field}_id", related_obj.id)
-                        interface.save()
                         print(
                             f"🧷 Created {related_field} interface {interface} on {interface.device}"
                         )
+
+                    setattr(interface, f"{related_field}_id", related_obj.id)
+                    interface.save()
 
 
 register_initializer("interfaces", InterfaceInitializer)


### PR DESCRIPTION
If an interface specifies a non-parent (e.g. 'lag') interface, establish the relationship when the related interface is pre-existing.

Previously the relationship was only established if the LAG interface was created as part of creating the member.  There was no way then to add a 2nd member to the LAG or pre-create the LAG interface with other attributes set.

Now, you can (optionally) pre-create the LAG with whatever attributes are required (e.g. MAC address) and then specifiy members and they will be added to the LAG.  Alternatively, you can omit the explicit specification of the LAG and have it create with the first member (as per previous behavior), subsequent interfaces specifying the same LAG will now join as expected. 