### PR TITLE
set attr from interfaces.yml

### DIFF
--- a/src/netbox_initializers/initializers/interfaces.py
+++ b/src/netbox_initializers/initializers/interfaces.py
@@ -48,6 +48,10 @@ class InterfaceInitializer(BaseInitializer):
 
             if created:
                 print(f"🧷 Created interface {interface} on {interface.device}")
+            else:
+                for name in defaults:
+                    setattr(interface, name, defaults[name])
+                interface.save()
 
             self.set_custom_fields_values(interface, custom_field_data)
             self.set_tags(interface, tags)

--- a/src/netbox_initializers/initializers/yaml/device_types.yml
+++ b/src/netbox_initializers/initializers/yaml/device_types.yml
@@ -16,6 +16,14 @@
 #   u_height: 0
 #   custom_field_data:
 #     text_field: Description
+# - model: TOR-8P
+#   manufacturer: No Name
+#   part_number: vlab-eos
+#   slug: tor-8p
+#   interfaces:
+#     - name: Ethernet1
+#       type: 1000base-t
+#       description: UPLINK
 # - model: Other
 #   manufacturer: No Name
 #   slug: other
@@ -27,14 +35,6 @@
 #       mgmt_only: True
 #     - name: eth1
 #       type: 1000base-t
-# - model: TOR-8P
-#   manufacturer: No Name
-#   part_number: vlab-eos
-#   slug: tor-8p
-#   interfaces:
-#     - name: Ethernet1
-#       type: 1000base-t
-#       description: UPLINK
 #   console_server_ports:
 #     - name_template: ttyS[1-48]
 #       type: rj-45

--- a/src/netbox_initializers/initializers/yaml/device_types.yml
+++ b/src/netbox_initializers/initializers/yaml/device_types.yml
@@ -28,7 +28,7 @@
 #     - name: eth1
 #       type: 1000base-t
 # - model: TOR-8P
-#   manufacturer: GNS3
+#   manufacturer: No Name
 #   part_number: vlab-eos
 #   slug: tor-8p
 #   interfaces:

--- a/src/netbox_initializers/initializers/yaml/device_types.yml
+++ b/src/netbox_initializers/initializers/yaml/device_types.yml
@@ -27,6 +27,14 @@
 #       mgmt_only: True
 #     - name: eth1
 #       type: 1000base-t
+# - model: TOR-8P
+#   manufacturer: GNS3
+#   part_number: vlab-eos
+#   slug: tor-8p
+#   interfaces:
+#     - name: Ethernet1
+#       type: 1000base-t
+#       description: UPLINK
 #   console_server_ports:
 #     - name_template: ttyS[1-48]
 #       type: rj-45

--- a/src/netbox_initializers/initializers/yaml/devices.yml
+++ b/src/netbox_initializers/initializers/yaml/devices.yml
@@ -59,5 +59,5 @@
 # - name: gns3-tor
 #   device_role: switch
 #   device_type: TOR-8P
-#   site: gns3
-#   rack: gns3
+#   site: SING 1
+#   rack: rack-03

--- a/src/netbox_initializers/initializers/yaml/devices.yml
+++ b/src/netbox_initializers/initializers/yaml/devices.yml
@@ -55,3 +55,9 @@
 #   custom_field_data:
 #     text_field: Description
 #
+## Templated device
+# - name: gns3-tor
+#   device_role: switch
+#   device_type: TOR-8P
+#   site: gns3
+#   rack: gns3

--- a/src/netbox_initializers/initializers/yaml/interfaces.yml
+++ b/src/netbox_initializers/initializers/yaml/interfaces.yml
@@ -34,3 +34,8 @@
 #   enabled: true
 #   type: virtual
 #   name: loopback
+
+## Example to add attributes on a templated interface
+# - name: Ethernet1
+#   mtu: 9100
+#   device: gns3-tor


### PR DESCRIPTION
I propose a little modification to allow setting attributes like MTU from interfaces.yml on a device where interfaces are templated.

Example:
device_types.yml:
```
- model: TOR-8P
  manufacturer: GNS3
  part_number: vlab-eos
  slug: tor-8p
  interfaces:
    - name: Ethernet1
      type: 1000base-t
      description: UPLINK
```

devices.yml:
```
- name: gns3-tor
  device_type: TOR-8P
```

interfaces.yml:
```
- name: Ethernet1
  mtu: 9100
  device: gns3-tor
```