### PR TITLE
custom_field object_time renamed to related_object_type

### DIFF
--- a/src/netbox_initializers/initializers/custom_fields.py
+++ b/src/netbox_initializers/initializers/custom_fields.py
@@ -61,19 +61,30 @@ class CustomFieldInitializer(BaseInitializer):
                 if cf_details.get("is_cloneable", None) is not None:
                     custom_field.is_cloneable = cf_details["is_cloneable"]
 
-                # object_type should only be applied when type is object, multiobject
+                # object_type was renamed to related_object_type in netbox 4.0
                 if cf_details.get("object_type"):
+                    print(
+                        f"⚠️ Unable to create Custom Field '{cf_name}': please rename object_type "
+                        + "to related_object_type"
+                    )
+                    custom_field.delete()
+                    continue
+
+                # related_object_type should only be applied when type is object, multiobject
+                if cf_details.get("related_object_type"):
                     if cf_details.get("type") not in (
                         "object",
                         "multiobject",
                     ):
                         print(
-                            f"⚠️ Unable to create Custom Field '{cf_name}': object_type is "
+                            f"⚠️ Unable to create Custom Field '{cf_name}': related_object_type is "
                             + "supported only for object and multiobject types"
                         )
                         custom_field.delete()
                         continue
-                    custom_field.object_type = get_class_for_class_path(cf_details["object_type"])
+                    custom_field.related_object_type = get_class_for_class_path(
+                        cf_details["related_object_type"]
+                    )
 
                 # validation_regex should only be applied when type is text, longtext, url
                 if cf_details.get("validation_regex"):

--- a/src/netbox_initializers/initializers/yaml/custom_fields.yml
+++ b/src/netbox_initializers/initializers/yaml/custom_fields.yml
@@ -100,7 +100,7 @@
 #   filter_logic: loose
 #   on_objects:
 #   - dcim.models.Location
-#   object_type: ipam.models.IPAddress
+#   related_object_type: ipam.models.IPAddress
 # object_field:
 #   type: object
 #   label: ASN
@@ -109,4 +109,4 @@
 #   filter_logic: loose
 #   on_objects:
 #   - dcim.models.Device
-#   object_type: ipam.models.ASN
+#   related_object_type: ipam.models.ASN


### PR DESCRIPTION
Netbox 4.0 changed object_type field to related_object_type in custom field model (https://github.com/netbox-community/netbox/pull/15366)
 
I've added code that checks if user has object_type defined in custom_fields YAML and warns but doesn't import that field. I can change it to handle the import as well if you like.