### PR TITLE
Fix custom field object type check

### DIFF
--- a/src/netbox_initializers/initializers/base.py
+++ b/src/netbox_initializers/initializers/base.py
@@ -52,7 +52,7 @@ class BaseInitializer:
                 missing_cfs.append(key)
             else:
                 ct = ObjectType.objects.get_for_model(entity)
-                if ct not in cf.object_types.all():
+                if not cf.object_types.filter(pk=ct.pk).exists():
                     print(
                         f"⚠️ Custom field {key} is not enabled for {entity}'s model!"
                         "Please check the 'on_objects' for that custom field in custom_fields.yml"


### PR DESCRIPTION
## Summary
Fixes a false-negative validation when applying `custom_field_data` from YAML initializers.
A custom field could be incorrectly reported as “not enabled for <model>”, even though it is enabled.

## Root cause
`ObjectType.objects.get_for_model()` returns NetBox's `ObjectType`, while `CustomField.object_types`
is a queryset of Django `ContentType` (or a different type depending on NetBox version).
Because the membership check compares different model classes, `ct not in cf.object_types.all()`
can evaluate to `True` even when the underlying content type matches.

## Changes
- Compare by primary key using `.filter(pk=ct.pk).exists()` instead of `ct in queryset`

## Reproduction
1. Create a Custom Field assigned to `IPAM > Prefix`
2. Reference it under `custom_field_data` in `prefixes.yml`
3. Run `load_initializer_data`
Before: prints “Custom field ... is not enabled for Prefix's model” and the value is not applied  
After: no false warning and the custom field value is applied

## Tested
- Tested on: NetBox v4.4.10 / netbox-initializers v4.4.0